### PR TITLE
Fix for #10 - Allow NetworkTransactionReference id to not be required

### DIFF
--- a/src/Models/NetworkTransactionReference.php
+++ b/src/Models/NetworkTransactionReference.php
@@ -18,7 +18,7 @@ use stdClass;
 class NetworkTransactionReference implements \JsonSerializable
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $id;
 
@@ -38,9 +38,9 @@ class NetworkTransactionReference implements \JsonSerializable
     private $acquirerReferenceNumber;
 
     /**
-     * @param string $id
+     * @param string|null $id
      */
-    public function __construct(string $id)
+    public function __construct(?string $id = null)
     {
         $this->id = $id;
     }
@@ -52,7 +52,7 @@ class NetworkTransactionReference implements \JsonSerializable
      * is the "NRID" field in response. The pattern we expect for this field from Visa/Amex/CB/Discover is
      * numeric, Mastercard/BNPP is alphanumeric and Paysecure is alphanumeric with special character -.
      */
-    public function getId(): string
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -64,10 +64,9 @@ class NetworkTransactionReference implements \JsonSerializable
      * is the "NRID" field in response. The pattern we expect for this field from Visa/Amex/CB/Discover is
      * numeric, Mastercard/BNPP is alphanumeric and Paysecure is alphanumeric with special character -.
      *
-     * @required
      * @maps id
      */
-    public function setId(string $id): void
+    public function setId(?string $id): void
     {
         $this->id = $id;
     }


### PR DESCRIPTION
 Allows the NetworkTransactionReference class to be instantiated without a transaction ID, and the JsonMapper will no longer throw an exception when the ID is not provided in the response.