### PR TITLE
Fixes #11 43 is invalid for PaymentAdviceCode

### DIFF
--- a/src/Models/PaymentAdviceCode.php
+++ b/src/Models/PaymentAdviceCode.php
@@ -28,7 +28,9 @@ class PaymentAdviceCode
 
     public const ENUM_21 = '21';
 
-    private const _ALL_VALUES = [self::ENUM_01, self::ENUM_02, self::ENUM_03, self::ENUM_21];
+    public const ENUM_43 = '43';
+
+    private const _ALL_VALUES = [self::ENUM_01, self::ENUM_02, self::ENUM_03, self::ENUM_21, self::ENUM_43];
 
     /**
      * Ensures that all the given values are present in this Enum.

--- a/src/Models/ProcessorResponse.php
+++ b/src/Models/ProcessorResponse.php
@@ -141,7 +141,12 @@ class ProcessorResponse implements \JsonSerializable
             $json['response_code']       = ProcessorResponseCode::checkValue($this->responseCode);
         }
         if (isset($this->paymentAdviceCode)) {
-            $json['payment_advice_code'] = PaymentAdviceCode::checkValue($this->paymentAdviceCode);
+            try {
+                $json['payment_advice_code'] = PaymentAdviceCode::checkValue($this->paymentAdviceCode);
+            } catch (Exception $e) {
+                // If the payment advice code is not recognized, just pass it through as-is
+                $json['payment_advice_code'] = $this->paymentAdviceCode;
+            }
         }
 
         return (!$asArrayWhenEmpty && empty($json)) ? new stdClass() : $json;


### PR DESCRIPTION
Added a new constant ENUM_43 with the value '43'
Including self::ENUM_43 in the _ALL_VALUES array
Updates ProcessorResponse class to handle unknown payment advice codes gracefully